### PR TITLE
Dynamic reloading of topic policy and kmsDefs files

### DIFF
--- a/kroxylicious-filter/pom.xml
+++ b/kroxylicious-filter/pom.xml
@@ -76,6 +76,12 @@
             <version>1.18.3</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.4.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/EncrypterDecrypter.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/EncrypterDecrypter.java
@@ -1,0 +1,10 @@
+package io.strimzi.kafka.topicenc.kroxylicious;
+
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+
+public interface EncrypterDecrypter {
+    public boolean encrypt(ProduceRequestData.TopicProduceData topicData);
+
+    public boolean decrypt(FetchResponseData.FetchableTopicResponse fetchRsp);
+}

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/EncryptionModuleEncrypterDecrypter.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/EncryptionModuleEncrypterDecrypter.java
@@ -6,6 +6,8 @@ import io.strimzi.kafka.topicenc.policy.JsonPolicyLoader;
 import io.strimzi.kafka.topicenc.policy.TopicPolicy;
 import org.apache.kafka.common.message.FetchResponseData;
 import org.apache.kafka.common.message.ProduceRequestData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,20 +17,41 @@ import java.util.List;
 import java.util.Map;
 
 public class EncryptionModuleEncrypterDecrypter implements EncrypterDecrypter {
+
+    private static final Logger logger = LoggerFactory.getLogger(EncryptionModuleEncrypterDecrypter.class);
     private static final Map<EncryptionModuleConfiguration, EncryptionModuleEncrypterDecrypter> crypters = new HashMap<>();
+    private static final FileWatcherService watcher = new FileWatcherService();
+    private EncryptionModule encryptionModule;
 
-    private final EncryptionModule encryptionModule;
-
-    public static EncrypterDecrypter getOrCreateInstance(File kmsDefsFile, File policyFile) {
+    public static EncrypterDecrypter getOrCreateInstance(File kmsDefsFile, File policyFile, boolean reloadOnFileChange) {
         EncryptionModuleConfiguration config = new EncryptionModuleConfiguration(kmsDefsFile.toPath(), policyFile.toPath());
-        return crypters.computeIfAbsent(config, encryptionModuleConfiguration -> new EncryptionModuleEncrypterDecrypter(config));
+        return crypters.computeIfAbsent(config, encryptionModuleConfiguration -> new EncryptionModuleEncrypterDecrypter(config, watcher, reloadOnFileChange));
     }
-
 
     record EncryptionModuleConfiguration(Path kmsDefsPath, Path topicPoliciesPath) {
     }
 
-    private EncryptionModuleEncrypterDecrypter(EncryptionModuleConfiguration configuration) {
+    private EncryptionModuleEncrypterDecrypter(EncryptionModuleConfiguration configuration, FileWatcherService watcher, boolean reloadOnFileChange) {
+        reload(configuration);
+        if (reloadOnFileChange) {
+            reloadOnFileChange(watcher, configuration.kmsDefsPath, configuration);
+            reloadOnFileChange(watcher, configuration.topicPoliciesPath, configuration);
+        }
+    }
+
+    private void reloadOnFileChange(FileWatcherService watcher, Path path, EncryptionModuleConfiguration configuration) {
+        watcher.watchFileForCreateOrModify(path, kind -> {
+            logger.info("file changed {}, reloading configuration", path);
+            reload(configuration);
+        }).thenAccept(watchId -> {
+            logger.info("Registered file change watchers for {}", path);
+        }).exceptionally(throwable -> {
+            logger.error("Failed to registered file change watchers for {}", path, throwable);
+            return null;
+        });
+    }
+
+    private void reload(EncryptionModuleConfiguration configuration) {
         try {
             encryptionModule = load(configuration.kmsDefsPath.toFile(), configuration.topicPoliciesPath.toFile());
         } catch (Exception e) {

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/EncryptionModuleEncrypterDecrypter.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/EncryptionModuleEncrypterDecrypter.java
@@ -1,0 +1,62 @@
+package io.strimzi.kafka.topicenc.kroxylicious;
+
+import io.strimzi.kafka.topicenc.EncryptionModule;
+import io.strimzi.kafka.topicenc.policy.InMemoryPolicyRepository;
+import io.strimzi.kafka.topicenc.policy.JsonPolicyLoader;
+import io.strimzi.kafka.topicenc.policy.TopicPolicy;
+import org.apache.kafka.common.message.FetchResponseData;
+import org.apache.kafka.common.message.ProduceRequestData;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EncryptionModuleEncrypterDecrypter implements EncrypterDecrypter {
+    private static final Map<EncryptionModuleConfiguration, EncryptionModuleEncrypterDecrypter> crypters = new HashMap<>();
+
+    private final EncryptionModule encryptionModule;
+
+    public static EncrypterDecrypter getOrCreateInstance(File kmsDefsFile, File policyFile) {
+        EncryptionModuleConfiguration config = new EncryptionModuleConfiguration(kmsDefsFile.toPath(), policyFile.toPath());
+        return crypters.computeIfAbsent(config, encryptionModuleConfiguration -> new EncryptionModuleEncrypterDecrypter(config));
+    }
+
+
+    record EncryptionModuleConfiguration(Path kmsDefsPath, Path topicPoliciesPath) {
+    }
+
+    private EncryptionModuleEncrypterDecrypter(EncryptionModuleConfiguration configuration) {
+        try {
+            encryptionModule = load(configuration.kmsDefsPath.toFile(), configuration.topicPoliciesPath.toFile());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create topic policies", e);
+        }
+    }
+
+    private EncryptionModule load(File kmsDefsFile, File policyFile) throws IOException {
+        List<TopicPolicy> topicPolicies = JsonPolicyLoader.loadTopicPolicies(kmsDefsFile, policyFile);
+        InMemoryPolicyRepository inMemoryPolicyRepository = new InMemoryPolicyRepository(topicPolicies);
+        return new EncryptionModule(inMemoryPolicyRepository);
+    }
+
+    @Override
+    public boolean encrypt(ProduceRequestData.TopicProduceData topicData) {
+        try {
+            return encryptionModule.encrypt(topicData);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean decrypt(FetchResponseData.FetchableTopicResponse fetchRsp) {
+        try {
+            return encryptionModule.decrypt(fetchRsp);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/FetchDecryptFilter.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/FetchDecryptFilter.java
@@ -4,7 +4,6 @@ import io.kroxylicious.proxy.filter.FetchRequestFilter;
 import io.kroxylicious.proxy.filter.FetchResponseFilter;
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.MetadataResponseFilter;
-import io.strimzi.kafka.topicenc.EncryptionModule;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.message.FetchRequestData;
 import org.apache.kafka.common.message.FetchResponseData;
@@ -32,10 +31,10 @@ public class FetchDecryptFilter implements FetchRequestFilter, FetchResponseFilt
     public static final short METADATA_VERSION_SUPPORTING_TOPIC_IDS = (short) 12;
     private final Map<Uuid, String> topicUuidToName = new HashMap<>();
 
-    private final EncryptionModule module;
+    private final EncrypterDecrypter module;
 
     public FetchDecryptFilter(TopicEncryptionConfig config) {
-        module = new EncryptionModule(config.getPolicyRepository());
+        module = config.encrypterDecrypter();
     }
 
     @Override

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcher.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcher.java
@@ -1,0 +1,174 @@
+package io.strimzi.kafka.topicenc.kroxylicious;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+
+/**
+ * Watches for modifications and creations of specified files, invoking a user
+ * supplied callback on modification. Note that the callback will be executed in the thread
+ * polling for File changes so work should be done reasonably quickly to not block other
+ * listeners.
+ */
+public class FileWatcher implements Closeable {
+    private static final Logger logger = LoggerFactory.getLogger(FileWatcher.class);
+    private final AtomicLong watchIds = new AtomicLong(0);
+
+    @Override
+    public void close() {
+        try {
+            logger.info("closing file watcher");
+            service.close();
+            logger.info("WatchService closed");
+        } catch (Exception e) {
+            logger.error("failed to close watch service", e);
+        }
+    }
+
+    public enum Kind {
+        CREATED, MODIFIED
+    }
+
+    record WatchFileRequest(Path file, Path directory, Consumer<Kind> onEvent,
+                            CompletableFuture<WatchId> registered) {
+
+    }
+
+    public record WatchId(long id) {
+    }
+
+    public record UnwatchFileRequest(WatchId id, CompletableFuture<Void> complete) {
+    }
+
+    public CompletableFuture<Void> unwatch(WatchId watchId) {
+        CompletableFuture<Void> complete = new CompletableFuture<>();
+        boolean add = unwatchFileRequestRequests.add(new UnwatchFileRequest(watchId, complete));
+        if (!add) {
+            throw new RuntimeException("Failed to add deregistration to queue");
+        } else {
+            return complete;
+        }
+    }
+
+    record RegisteredFileWatch(WatchId id, WatchFileRequest watch, WatchKey key) {
+
+        public boolean matches(WatchKey poll, Path relativePath) {
+            return key.equals(poll) && watch.directory.resolve(relativePath).equals(watch.file);
+        }
+    }
+
+    ArrayBlockingQueue<WatchFileRequest> watchRequests = new ArrayBlockingQueue<>(100);
+    ArrayBlockingQueue<UnwatchFileRequest> unwatchFileRequestRequests = new ArrayBlockingQueue<>(100);
+    WatchService service;
+    List<RegisteredFileWatch> fileWatchList = new ArrayList<>();
+
+    private static final Map<WatchEvent.Kind<?>, Kind> interested = Map.of(ENTRY_CREATE, Kind.CREATED, ENTRY_MODIFY, Kind.MODIFIED);
+
+    public FileWatcher() {
+        try {
+            service = FileSystems.getDefault().newWatchService();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    void poll() {
+        drainWatchFileRequests();
+        drainUnwatchFileRequests();
+        pollForFileSystemChanges();
+    }
+
+    private void drainUnwatchFileRequests() {
+        UnwatchFileRequest toRemove;
+        while ((toRemove = unwatchFileRequestRequests.poll()) != null) {
+            try {
+                WatchId finalToRemove = toRemove.id;
+                fileWatchList.removeIf(registeredFileWatch -> registeredFileWatch.id.equals(finalToRemove));
+                logger.info("Removed watcher for {}", toRemove);
+                toRemove.complete.complete(null);
+            } catch (Exception e) {
+                logger.error("Failed to remove watcher for {}", toRemove);
+                toRemove.complete.completeExceptionally(e);
+            }
+        }
+    }
+
+    public CompletableFuture<WatchId> watchFileForCreateOrModify(Path path, Consumer<Kind> onChange) {
+        if (!Files.isRegularFile(path)) {
+            logger.error("attempted to watch a path that is not a file {}", path);
+            throw new IllegalArgumentException(path + " is not a file");
+        }
+        Path absolutePath = path.toAbsolutePath();
+        CompletableFuture<WatchId> registered = new CompletableFuture<>();
+        boolean add = watchRequests.add(new WatchFileRequest(absolutePath, absolutePath.getParent(), onChange, registered));
+        if (add) {
+            logger.info("added registration to queue for {}", path);
+        } else {
+            logger.error("failed to add registration to queue for {}", path);
+            throw new RuntimeException(path + " is not a file");
+        }
+        return registered;
+    }
+
+    private void pollForFileSystemChanges() {
+        if (fileWatchList.isEmpty()) {
+            return;
+        }
+        WatchKey poll = service.poll();
+        if (poll != null) {
+            List<WatchEvent<?>> watchEvents = poll.pollEvents();
+            for (WatchEvent<?> watchEvent : watchEvents) {
+                if (interested.containsKey(watchEvent.kind())) {
+                    Path path = (Path) watchEvent.context();
+                    for (RegisteredFileWatch fileWatch : fileWatchList) {
+                        if (fileWatch.matches(poll, path)) {
+                            Kind kind = interested.get(watchEvent.kind());
+                            logger.info("file {} detected for {}", kind, fileWatch.watch.file);
+                            try {
+                                fileWatch.watch.onEvent.accept(kind);
+                            } catch (Exception e) {
+                                logger.error("exception thrown while invoking users event handler", e);
+                            }
+                        }
+                    }
+                }
+            }
+            poll.reset();
+        }
+    }
+
+    private void drainWatchFileRequests() {
+        WatchFileRequest watch;
+        while ((watch = watchRequests.poll()) != null) {
+            try {
+                WatchKey key = watch.directory.register(service, ENTRY_CREATE, ENTRY_MODIFY);
+                WatchId id = new WatchId(watchIds.incrementAndGet());
+                fileWatchList.add(new RegisteredFileWatch(id, watch, key));
+                logger.info("Registered watcher for {}", watch.file);
+                watch.registered.complete(id);
+            } catch (Exception e) {
+                logger.error("Failed to register watcher for {}", watch.file);
+                watch.registered.completeExceptionally(e);
+            }
+        }
+    }
+
+}

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcherService.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcherService.java
@@ -1,0 +1,57 @@
+package io.strimzi.kafka.topicenc.kroxylicious;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public class FileWatcherService implements Closeable, Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(FileWatcherService.class);
+    private final FileWatcher watcher;
+    private final ScheduledExecutorService executor;
+    private boolean running = true;
+
+    public FileWatcherService() {
+        this(Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "topic-encryption-file-watcher")), new FileWatcher());
+    }
+
+    public FileWatcherService(ScheduledExecutorService executor, FileWatcher watcher) {
+        this.watcher = watcher;
+        this.executor = executor;
+        this.executor.execute(this);
+    }
+
+    @Override
+    public void close() {
+        logger.info("stopping file watcher work");
+        running = false;
+    }
+
+    public CompletableFuture<Void> unwatch(FileWatcher.WatchId watchId) {
+        return watcher.unwatch(watchId);
+    }
+
+    public CompletableFuture<FileWatcher.WatchId> watchFileForCreateOrModify(Path path, Consumer<FileWatcher.Kind> onChange) {
+        return watcher.watchFileForCreateOrModify(path, onChange);
+    }
+
+    @Override
+    public void run() {
+        if (running) {
+            try {
+                watcher.poll();
+            } catch (Exception e) {
+                logger.error("Error while polling file watcher, continuing to reschedule", e);
+            }
+            executor.schedule(this, 1, TimeUnit.SECONDS);
+        } else {
+            logger.info("service was closed, stopping work");
+        }
+    }
+}

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/InMemoryPolicyRepositoryConfig.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/InMemoryPolicyRepositoryConfig.java
@@ -3,22 +3,19 @@ package io.strimzi.kafka.topicenc.kroxylicious;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kroxylicious.proxy.config.BaseConfig;
-import io.strimzi.kafka.topicenc.policy.InMemoryPolicyRepository;
-import io.strimzi.kafka.topicenc.policy.JsonPolicyLoader;
-import io.strimzi.kafka.topicenc.policy.PolicyRepository;
-import io.strimzi.kafka.topicenc.policy.TopicPolicy;
 
 import java.io.File;
-import java.util.List;
 
 public class InMemoryPolicyRepositoryConfig extends BaseConfig {
 
     public static final String KMS_DEFINITIONS_FILE_PROP_NAME = "kmsDefinitionsFile";
     public static final String TOPIC_POLICIES_FILE_PROP_NAME = "topicPoliciesFile";
-    private final PolicyRepository policyRepository;
+
+    private final EncrypterDecrypter encrypterDecrypter;
 
     @JsonCreator
-    public InMemoryPolicyRepositoryConfig(@JsonProperty(KMS_DEFINITIONS_FILE_PROP_NAME) String kmsDefinitionsFile, @JsonProperty(TOPIC_POLICIES_FILE_PROP_NAME) String topicPoliciesFile) {
+    public InMemoryPolicyRepositoryConfig(@JsonProperty(KMS_DEFINITIONS_FILE_PROP_NAME) String kmsDefinitionsFile,
+                                          @JsonProperty(TOPIC_POLICIES_FILE_PROP_NAME) String topicPoliciesFile) {
         File kmsDefsFile = new File(kmsDefinitionsFile);
         if (!kmsDefsFile.exists()) {
             throw new IllegalArgumentException(KMS_DEFINITIONS_FILE_PROP_NAME + " " + kmsDefinitionsFile + " does not exist");
@@ -28,14 +25,13 @@ public class InMemoryPolicyRepositoryConfig extends BaseConfig {
             throw new IllegalArgumentException(TOPIC_POLICIES_FILE_PROP_NAME + " " + policyFile + " does not exist");
         }
         try {
-            List<TopicPolicy> topicPolicies = JsonPolicyLoader.loadTopicPolicies(kmsDefsFile, policyFile);
-            policyRepository = new InMemoryPolicyRepository(topicPolicies);
+            encrypterDecrypter = EncryptionModuleEncrypterDecrypter.getOrCreateInstance(kmsDefsFile, policyFile);
         } catch (Exception e) {
             throw new RuntimeException("Failed to create topic policies", e);
         }
     }
 
-    public PolicyRepository getPolicyRepository() {
-        return policyRepository;
+    public EncrypterDecrypter encrypterDecrypter(){
+        return encrypterDecrypter;
     }
 }

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/InMemoryPolicyRepositoryConfig.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/InMemoryPolicyRepositoryConfig.java
@@ -10,12 +10,14 @@ public class InMemoryPolicyRepositoryConfig extends BaseConfig {
 
     public static final String KMS_DEFINITIONS_FILE_PROP_NAME = "kmsDefinitionsFile";
     public static final String TOPIC_POLICIES_FILE_PROP_NAME = "topicPoliciesFile";
+    public static final String RELOAD_ON_FILE_CHANGE_PROP_NAME = "reloadOnFileChange";
 
     private final EncrypterDecrypter encrypterDecrypter;
 
     @JsonCreator
     public InMemoryPolicyRepositoryConfig(@JsonProperty(KMS_DEFINITIONS_FILE_PROP_NAME) String kmsDefinitionsFile,
-                                          @JsonProperty(TOPIC_POLICIES_FILE_PROP_NAME) String topicPoliciesFile) {
+                                          @JsonProperty(TOPIC_POLICIES_FILE_PROP_NAME) String topicPoliciesFile,
+                                          @JsonProperty(value = RELOAD_ON_FILE_CHANGE_PROP_NAME, defaultValue = "false") boolean reloadOnFileChange) {
         File kmsDefsFile = new File(kmsDefinitionsFile);
         if (!kmsDefsFile.exists()) {
             throw new IllegalArgumentException(KMS_DEFINITIONS_FILE_PROP_NAME + " " + kmsDefinitionsFile + " does not exist");
@@ -25,13 +27,13 @@ public class InMemoryPolicyRepositoryConfig extends BaseConfig {
             throw new IllegalArgumentException(TOPIC_POLICIES_FILE_PROP_NAME + " " + policyFile + " does not exist");
         }
         try {
-            encrypterDecrypter = EncryptionModuleEncrypterDecrypter.getOrCreateInstance(kmsDefsFile, policyFile);
+            encrypterDecrypter = EncryptionModuleEncrypterDecrypter.getOrCreateInstance(kmsDefsFile, policyFile, reloadOnFileChange);
         } catch (Exception e) {
             throw new RuntimeException("Failed to create topic policies", e);
         }
     }
 
-    public EncrypterDecrypter encrypterDecrypter(){
+    public EncrypterDecrypter encrypterDecrypter() {
         return encrypterDecrypter;
     }
 }

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/ProduceEncryptFilter.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/ProduceEncryptFilter.java
@@ -2,7 +2,6 @@ package io.strimzi.kafka.topicenc.kroxylicious;
 
 import io.kroxylicious.proxy.filter.KrpcFilterContext;
 import io.kroxylicious.proxy.filter.ProduceRequestFilter;
-import io.strimzi.kafka.topicenc.EncryptionModule;
 import org.apache.kafka.common.message.ProduceRequestData;
 import org.apache.kafka.common.message.ProduceResponseData;
 import org.apache.kafka.common.message.RequestHeaderData;
@@ -15,10 +14,10 @@ public class ProduceEncryptFilter implements ProduceRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(ProduceEncryptFilter.class);
 
-    private final EncryptionModule module;
+    private final EncrypterDecrypter module;
 
     public ProduceEncryptFilter(TopicEncryptionConfig config) {
-        module = new EncryptionModule(config.getPolicyRepository());
+        module = config.encrypterDecrypter();
     }
 
     @Override

--- a/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/TopicEncryptionConfig.java
+++ b/kroxylicious-filter/src/main/java/io/strimzi/kafka/topicenc/kroxylicious/TopicEncryptionConfig.java
@@ -3,7 +3,6 @@ package io.strimzi.kafka.topicenc.kroxylicious;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kroxylicious.proxy.config.BaseConfig;
-import io.strimzi.kafka.topicenc.policy.PolicyRepository;
 
 import java.util.Objects;
 
@@ -19,7 +18,7 @@ public class TopicEncryptionConfig extends BaseConfig {
                 + " configuration is required as it is the only PolicyRepository implementation");
     }
 
-    public PolicyRepository getPolicyRepository() {
-        return inMemoryPolicyRepository.getPolicyRepository();
+    public EncrypterDecrypter encrypterDecrypter() {
+        return inMemoryPolicyRepository.encrypterDecrypter();
     }
 }

--- a/kroxylicious-filter/src/test/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcherServiceTest.java
+++ b/kroxylicious-filter/src/test/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcherServiceTest.java
@@ -1,0 +1,139 @@
+package io.strimzi.kafka.topicenc.kroxylicious;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.toCollection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class FileWatcherServiceTest {
+    @Spy
+    private FakeClock clock;
+    @Spy
+    private FakeScheduledExecutorService executor;
+    @Mock
+    FileWatcher watcher;
+
+    @Test
+    public void testRescheduledOnSuccess() {
+        new FileWatcherService(executor, watcher);
+        assertEquals(1, executor.pending());
+        executor.run();
+        Mockito.verify(watcher).poll();
+        assertEquals(1, executor.pending());
+        clock.elapse(Duration.of(1, ChronoUnit.SECONDS));
+        executor.run();
+        Mockito.verify(watcher, times(2)).poll();
+        assertEquals(1, executor.pending());
+    }
+
+    @Test
+    public void testRescheduleDuration() {
+        new FileWatcherService(executor, watcher);
+        assertEquals(1, executor.pending());
+        executor.run();
+        Mockito.verify(watcher).poll();
+        assertEquals(1, executor.pending());
+        clock.elapse(Duration.of(999, ChronoUnit.MILLIS));
+        executor.run();
+        Mockito.verify(watcher, times(1)).poll();
+        clock.elapse(Duration.of(1, ChronoUnit.MILLIS));
+        executor.run();
+        Mockito.verify(watcher, times(2)).poll();
+        assertEquals(1, executor.pending());
+    }
+
+    @Test
+    public void testCloseStopsWorkAndStopsRescheduling() {
+        FileWatcherService fileWatcherService = new FileWatcherService(executor, watcher);
+        assertEquals(1, executor.pending());
+        fileWatcherService.close();
+        executor.run();
+        Mockito.verify(watcher, never()).poll();
+        assertEquals(0, executor.pending());
+    }
+
+    @Test
+    public void testOtherPollExceptionKeepsRescheduling() {
+        new FileWatcherService(executor, watcher);
+        assertEquals(1, executor.pending());
+        Mockito.doThrow(new RuntimeException("failed to poll! should be non-fatal")).when(watcher).poll();
+        executor.run();
+        Mockito.verify(watcher, times(1)).poll();
+        assertEquals(1, executor.pending());
+    }
+
+    static abstract class FakeClock extends Clock {
+        private Instant now = Instant.ofEpochMilli(0);
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+
+        void elapse(Duration duration) {
+            now = now.plus(duration);
+        }
+    }
+
+    record Job(Runnable runnable, long delay, TemporalUnit unit, Instant created) {
+
+        public boolean ready(Instant now) {
+            return now.compareTo(created.plus(delay, unit)) >= 0;
+        }
+
+        public void run() {
+            runnable.run();
+        }
+    }
+
+    abstract class FakeScheduledExecutorService
+            implements ScheduledExecutorService {
+        private List<Job> jobs = new ArrayList<>();
+
+        @Override
+        public ScheduledFuture<?> schedule(
+                @NotNull Runnable command, long delay, TimeUnit unit) {
+            jobs.add(new Job(command, delay, unit.toChronoUnit(), clock.instant()));
+            return Mockito.mock(ScheduledFuture.class);
+        }
+
+        @Override
+        public void execute(@NotNull Runnable command) {
+            jobs.add(new Job(command, 0, ChronoUnit.MILLIS, clock.instant()));
+        }
+
+        void run() {
+            Instant now = clock.instant();
+            List<Job> ready = jobs.stream().filter(job -> job.ready(now)).toList();
+            jobs = jobs.stream()
+                    .filter(job -> !job.ready(now))
+                    .collect(toCollection(ArrayList::new));
+            ready.forEach(Job::run);
+        }
+
+        public int pending() {
+            return jobs.size();
+        }
+    }
+
+}

--- a/kroxylicious-filter/src/test/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcherTest.java
+++ b/kroxylicious-filter/src/test/java/io/strimzi/kafka/topicenc/kroxylicious/FileWatcherTest.java
@@ -1,0 +1,127 @@
+package io.strimzi.kafka.topicenc.kroxylicious;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class FileWatcherTest {
+
+    @Test
+    public void testChange(@TempDir Path tempDir) throws Exception {
+        Path tempfile = tempDir.resolve("tempfile");
+        Files.writeString(tempfile, "ABC");
+        CompletableFuture<FileWatcher.Kind> change = new CompletableFuture<>();
+        try (FileWatcher watcher = new FileWatcher()) {
+            CompletableFuture<FileWatcher.WatchId> watchIdCompletableFuture = watcher.watchFileForCreateOrModify(tempfile, change::complete);
+            pollUntil(watcher, () -> watchIdCompletableFuture.getNow(null) != null);
+            Files.writeString(tempfile, "DEF", StandardOpenOption.APPEND);
+            pollUntil(watcher, () -> FileWatcher.Kind.MODIFIED.equals(change.getNow(null)));
+        }
+    }
+
+    @Test
+    public void testDeregister(@TempDir Path tempDir) throws Exception {
+        Path tempfile = tempDir.resolve("tempfile");
+        Files.writeString(tempfile, "ABC");
+        CompletableFuture<FileWatcher.Kind> change = new CompletableFuture<>();
+        try (FileWatcher fileWatcher = new FileWatcher()) {
+            CompletableFuture<FileWatcher.WatchId> watchIdCompletableFuture = fileWatcher.watchFileForCreateOrModify(tempfile, change::complete);
+            pollUntil(fileWatcher, () -> watchIdCompletableFuture.getNow(null) != null);
+            CompletableFuture<Void> unwatch = fileWatcher.unwatch(watchIdCompletableFuture.getNow(null));
+            pollUntil(fileWatcher, unwatch::isDone);
+            Files.writeString(tempfile, "DEF", StandardOpenOption.APPEND);
+            fileWatcher.poll();
+            assertFalse(change.isDone());
+        }
+    }
+
+    // this tests that we reset the WatchKey after each event
+    @Test
+    public void testMultipleChanges(@TempDir Path tempDir) throws Exception {
+        Path tempfile = tempDir.resolve("tempfile");
+        Files.writeString(tempfile, "ABC");
+        AtomicLong invocations = new AtomicLong();
+        try (FileWatcher fileWatcher = new FileWatcher()) {
+            CompletableFuture<FileWatcher.WatchId> future = fileWatcher.watchFileForCreateOrModify(tempfile, kind -> {
+                if (kind == FileWatcher.Kind.MODIFIED) {
+                    invocations.incrementAndGet();
+                }
+            });
+            pollUntil(fileWatcher, () -> future.getNow(null) != null);
+            Files.writeString(tempfile, "DEF", StandardOpenOption.APPEND);
+            pollUntil(fileWatcher, () -> invocations.get() == 1);
+            Files.writeString(tempfile, "HIJ", StandardOpenOption.APPEND);
+            pollUntil(fileWatcher, () -> invocations.get() == 2);
+        }
+    }
+
+    // this tests that we reset the WatchKey after each event
+    @Test
+    public void testMultipleRecreations(@TempDir Path tempDir) throws Exception {
+        Path tempfile = tempDir.resolve("tempfile");
+        Files.writeString(tempfile, "ABC");
+        AtomicLong invocations = new AtomicLong();
+        try (FileWatcher fileWatcher = new FileWatcher()) {
+            CompletableFuture<FileWatcher.WatchId> future = fileWatcher.watchFileForCreateOrModify(tempfile, kind -> {
+                if (kind == FileWatcher.Kind.CREATED) {
+                    invocations.incrementAndGet();
+                }
+            });
+            pollUntil(fileWatcher, () -> future.getNow(null) != null);
+            Files.delete(tempfile);
+            Files.writeString(tempfile, "DEF");
+            pollUntil(fileWatcher, () -> invocations.get() == 1);
+            Files.delete(tempfile);
+            Files.writeString(tempfile, "HIJ");
+            pollUntil(fileWatcher, () -> invocations.get() == 2);
+        }
+    }
+
+    @Test
+    public void testRecreate(@TempDir Path tempDir) throws Exception {
+        Path tempfile = tempDir.resolve("tempfile");
+        Files.writeString(tempfile, "ABC");
+        CompletableFuture<FileWatcher.Kind> change = new CompletableFuture<>();
+        try (FileWatcher fileWatcher = new FileWatcher()) {
+            CompletableFuture<FileWatcher.WatchId> future = fileWatcher.watchFileForCreateOrModify(tempfile, change::complete);
+            pollUntil(fileWatcher, () -> future.getNow(null) != null);
+            Files.delete(tempfile);
+            Files.writeString(tempfile, "DEF");
+            pollUntil(fileWatcher, () -> FileWatcher.Kind.CREATED.equals(change.getNow(null)));
+        }
+    }
+
+    @Test
+    public void testChangeNotifiesMultipleWatchers(@TempDir Path tempDir) throws Exception {
+        Path tempfile = tempDir.resolve("tempfile");
+        Files.writeString(tempfile, "ABC");
+        CompletableFuture<FileWatcher.Kind> change = new CompletableFuture<>();
+        CompletableFuture<FileWatcher.Kind> change2 = new CompletableFuture<>();
+        try (FileWatcher fileWatcher = new FileWatcher()) {
+            CompletableFuture<FileWatcher.WatchId> future1 = fileWatcher.watchFileForCreateOrModify(tempfile, change::complete);
+            CompletableFuture<FileWatcher.WatchId> future2 = fileWatcher.watchFileForCreateOrModify(tempfile, change2::complete);
+            pollUntil(fileWatcher, () -> future1.getNow(null) != null && future2.getNow(null) != null);
+
+            Files.writeString(tempfile, "DEF", StandardOpenOption.APPEND);
+            pollUntil(fileWatcher, () -> FileWatcher.Kind.MODIFIED.equals(change.getNow(null)) && FileWatcher.Kind.MODIFIED.equals(change2.getNow(null)));
+        }
+    }
+
+    public void pollUntil(FileWatcher watcher, Callable<Boolean> test) {
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> {
+            watcher.poll();
+            return test.call();
+        });
+    }
+
+}


### PR DESCRIPTION
This change introduces a `FileWatcher` class to watch for changes to the files and execute a callback when they are modified or recreated. This is driven by `FileWatcherService`, which creates a single thread to poll for changes and execute the callbacks. Registration of new files is also done asynchronously between polls to the watch service to keep it single threaded and easy to reason about, at the cost of delaying registration while we are blocked waiting for changes.

The encrypt/decrypt filters now obtain an `EncrypterDecrypter` through a static factory, so multiple channels will have access to the same EncrypterDecrypter if they refer to the same configuration file paths. The EncrypterDecrypter wraps the EncryptionModule so that a new one can be reloaded and swapped in if the configuration files change. From my read of the code EncryptionModule is threadsafe, but would be great to get more eyes on that.

If we have to change to an EncryptionModule instance per channel then there may be issues around resources leaking as we have no hooks into the lifecycle of the Filter. See https://github.com/kroxylicious/kroxylicious/pull/496.

Why:

It could be useful to support the topicPolicy and kmsDef files being updated so that Kroxylicious could apply policies to new topics without being restarted and forcing all clients to reconnect.